### PR TITLE
name added in ColorResource.kt to support runtime theme switch in iOS

### DIFF
--- a/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/ColorsGenerator.kt
+++ b/resources-generator/src/main/kotlin/dev/icerock/gradle/generator/ColorsGenerator.kt
@@ -72,9 +72,9 @@ abstract class ColorsGenerator(
     protected open fun getPropertyModifiers(): Array<KModifier> = emptyArray()
     protected open fun getPropertyInitializer(color: ColorNode): CodeBlock? {
         val className = if (color.isThemed()) {
-            "Themed(light = Color(0x${color.lightColor}), dark = Color(0x${color.darkColor}))"
+            "Themed(light = Color(0x${color.lightColor}), dark = Color(0x${color.darkColor}), name = \"${color.name}\")"
         } else {
-            "Single(color = Color(0x${color.singleColor}))"
+            "Single(color = Color(0x${color.singleColor}), name = \"${color.name}\")"
         }
         return CodeBlock.of(className)
     }

--- a/resources-test/src/commonMain/kotlin/dev/icerock/moko/resources/test/createColorResourceMock.kt
+++ b/resources-test/src/commonMain/kotlin/dev/icerock/moko/resources/test/createColorResourceMock.kt
@@ -7,4 +7,4 @@ package dev.icerock.moko.resources.test
 import dev.icerock.moko.graphics.Color
 import dev.icerock.moko.resources.ColorResource
 
-fun createColorResourceMock(): ColorResource = ColorResource.Single(Color(0, 0, 0, 0))
+fun createColorResourceMock(): ColorResource = ColorResource.Single(Color(0, 0, 0, 0),"black")

--- a/resources/src/commonMain/kotlin/dev/icerock/moko/resources/ColorResource.kt
+++ b/resources/src/commonMain/kotlin/dev/icerock/moko/resources/ColorResource.kt
@@ -6,8 +6,8 @@ package dev.icerock.moko.resources
 
 import dev.icerock.moko.graphics.Color
 
-sealed class ColorResource {
-    class Single(val color: Color) : ColorResource()
+sealed class ColorResource(val name:String) {
+    class Single(val color: Color, name: String) : ColorResource(name)
 
-    class Themed(val light: Color, val dark: Color) : ColorResource()
+    class Themed(val light: Color, val dark: Color, name: String) : ColorResource(name)
 }

--- a/resources/src/iosMain/kotlin/dev/icerock/moko/resources/ColorResourceExt.kt
+++ b/resources/src/iosMain/kotlin/dev/icerock/moko/resources/ColorResourceExt.kt
@@ -5,7 +5,9 @@
 package dev.icerock.moko.resources
 
 import dev.icerock.moko.graphics.Color
+import platform.UIKit.UIColor
 import platform.UIKit.UIUserInterfaceStyle
+import platform.UIKit.colorNamed
 
 fun ColorResource.getColor(userInterfaceStyle: UIUserInterfaceStyle): Color {
     return when (this) {
@@ -21,4 +23,15 @@ fun ColorResource.getColor(userInterfaceStyle: UIUserInterfaceStyle): Color {
             }
         }
     }
+}
+
+/**
+ * Returns null if no color asset is found in the ios app. update and configure copyColorAssetsToIOSApp in your ios run script to automate the copy process.
+ *       val copyColorAssetsToIOSApp = tasks.register<Copy>("copyColorAssetsToIOSApp") {
+ *              from("$rootDir/resources/build/generated/moko/iosMain/res/Assets.xcassets")
+ *              into("$rootDir/iosApp/iosApp/Assets.xcassets/colors")
+ *       }
+ */
+fun ColorResource.getThemeColor(): UIColor {
+    return UIColor.colorNamed(this.name)!!
 }


### PR DESCRIPTION
 To support runtime Theme switch in ios the files need to be copied to iosApp. which can be automated by a gradle task like below and configure it as iOS  run script.

val copyColorAssetsToIOSApp = tasks.register<Copy>("copyColorAssetsToIOSApp") {
    from("$rootDir/resources/build/generated/moko/iosMain/res/Assets.xcassets")
    into("$rootDir/iosApp/iosApp/Assets.xcassets/colors")
}

Now to get the color from the iOS app assets we need to use UIColor.colorNamed(“colorName”) function. Below extension method can be used for that

fun ColorResource.getThemeColor(): UIColor {
   return UIColor.colorNamed(this.name)!!
}